### PR TITLE
Add string validators

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -339,20 +339,19 @@ class TestValidator(object):
 
     def test_contains_validator(self):
         validation = {
-            # "foo": [Required, Contains("1")],
-            # "qux": [Required, Not(Contains("1"))]
+            "foo": [Required, Contains("1")],
             "qux": 'required|not.contains:1' #== [Required, Not(Contains("1"))]
         }
         test_case_list = {
-            # "foo": ["1", "2", "3"],
+            "foo": ["1", "2", "3"],
             "qux": ["2", "3", "4"]
         }
         test_case_dict = {
-            # "foo": {"1": "one", "2": "two"},
+            "foo": {"1": "one", "2": "two"},
             "qux": {"2": "two", "3": "three"}
         }
         test_case_substring = {
-            # "foo": "test1case",
+            "foo": "test1case",
             "qux": "barbaz"
         }
         assert validate(validation, test_case_list)[0]

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -507,21 +507,20 @@ class TestValidator(object):
         assert len(errors) == len(fails)
 
 
-class TestValidationMapper:
+mapper = ValidationMapper()
 
-    def setup_method(self):
-        self.mapper = ValidationMapper()
+class TestValidationMapper:
     
     def test_can_make_required(self):
-        assert self.mapper.make('required') == [Required]
+        assert mapper.make('required') == [Required]
 
     def test_can_make_multiple_from_string(self):
-        validator = self.mapper.make('required|email')
+        validator = mapper.make('required|email')
         assert validator[0] == Required
         assert isinstance(validator[1], Email)
 
     def test_can_make_multiple_from_string_with_inputs(self):
-        validator = self.mapper.make('length:1,2')
+        validator = mapper.make('length:1,2')
         assert isinstance(validator[0], Length)
 
     def test_can_pass_validation(self):

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -533,7 +533,7 @@ class TestValidationMapper:
         }
 
         validation = {
-            "foo": 'email|required',
+            "foo": ['email|length:1,18', Required],
         }
 
         valid, errors = validate(validation, passes)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -454,7 +454,7 @@ class TestValidator(object):
             "qux": "/1https://vk.com",
         }
         validation = {
-            "foo": [Url()],
+            "foo": 'url',
             "bar": [Url()],
             "foobar": [Url()],
             "baz": [Url()],
@@ -477,7 +477,6 @@ class TestValidator(object):
             "foobar": "test@site.co",
             "foobarbaz": '"email"@domain.com',
             "foobarbazfoo": "email@domain-one.com",
-
         }
 
         fails = {

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -483,32 +483,23 @@ class TestValidator(object):
                 })
             ]
         }
-        str_validation = {
-            "foo": [Required, Each([Range(0, 10)])],
-            "bar": [Required, Each({
-                    "qux": [Required, Range(0, 2)],
-                    "zot": [In([1, 2, 3])]
-                })
-            ]
-        }
         
-        for validation in (validation, str_validation):
-            valid, errors = validate(validation, passes)
-            assert valid
-            assert len(errors) == 0
-            valid, errors = validate(validation, fails)
-            assert not valid
-            assert len(errors) == 2
-            assert errors == {
-                "foo": ["all values must fall between 0 and 10"],
-                "bar": [{
-                    0: {"qux": ["must fall between 0 and 2"]},
-                    1: {
-                        "qux": ["must fall between 0 and 2"],
-                        "zot": ["must be one of [1, 2, 3]"]
-                    }
-                }]
-            }
+        valid, errors = validate(validation, passes)
+        assert valid
+        assert len(errors) == 0
+        valid, errors = validate(validation, fails)
+        assert not valid
+        assert len(errors) == 2
+        assert errors == {
+            "foo": ["all values must fall between 0 and 10"],
+            "bar": [{
+                0: {"qux": ["must fall between 0 and 2"]},
+                1: {
+                    "qux": ["must fall between 0 and 2"],
+                    "zot": ["must be one of [1, 2, 3]"]
+                }
+            }]
+        }
 
     def test_exception_handling(self):
         validation = {
@@ -542,19 +533,28 @@ class TestValidator(object):
             "qux": "/1https://vk.com",
         }
         validation = {
-            "foo": 'url',
+            "foo": [Url()],
             "bar": [Url()],
             "foobar": [Url()],
             "baz": [Url()],
             "qux": [Url()],
         }
 
-        valid, errors = validate(validation, passes)
-        assert valid
-        assert len(errors) == 0
-        valid, errors = validate(validation, fails)
-        assert not valid
-        assert len(errors) == 4
+        str_validation = {
+            "foo": 'url',
+            "bar": 'url',
+            "foobar": 'url',
+            "baz": 'url',
+            "qux": 'url',
+        }
+        
+        for validation in (validation, str_validation):
+            valid, errors = validate(validation, passes)
+            assert valid
+            assert len(errors) == 0
+            valid, errors = validate(validation, fails)
+            assert not valid
+            assert len(errors) == 4
 
     def test_email_validator(self):
         passes = {
@@ -576,7 +576,7 @@ class TestValidator(object):
         }
 
         validation = {
-            "foo": [Required, Email()],
+            "foo": [Email()],
             "bar": [Email()],
             "baz": [Email()],
             "barbaz": [Email()],
@@ -585,13 +585,24 @@ class TestValidator(object):
             "foobarbazfoo": [Email()],
         }
 
-        valid, errors = validate(validation, passes)
-        assert valid
-        assert len(errors) == 0
+        str_validation = {
+            "foo": 'email',
+            "bar": 'email',
+            "baz": 'email',
+            "barbaz": 'email',
+            "foobar": 'email',
+            "foobarbaz": 'email',
+            "foobarbazfoo": 'email',
+        }
 
-        valid, errors = validate(validation, fails)
-        assert not valid
-        assert len(errors) == len(fails)
+        for validation in (validation, str_validation):
+            valid, errors = validate(validation, passes)
+            assert valid
+            assert len(errors) == 0
+
+            valid, errors = validate(validation, fails)
+            assert not valid
+            assert len(errors) == len(fails)
 
 
 mapper = ValidationMapper()

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -259,7 +259,8 @@ class TestValidator(object):
 
     def test_pattern_validator(self):
         validator = {
-            "match": [Required, Pattern(r'\d\d\%')],
+            # "match": [Required, Pattern(r'')],
+            "match": 'required|pattern:\d\d\%',
             "no_match": [Required, Not(Pattern(r'\d\d\%'))]
         }
         test_case = {
@@ -532,7 +533,7 @@ class TestValidationMapper:
         }
 
         validation = {
-            "foo": 'email:required',
+            "foo": 'email|required',
         }
 
         valid, errors = validate(validation, passes)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -339,19 +339,20 @@ class TestValidator(object):
 
     def test_contains_validator(self):
         validation = {
-            "foo": [Required, Contains("1")],
-            "qux": [Required, Not(Contains("1"))]
+            # "foo": [Required, Contains("1")],
+            # "qux": [Required, Not(Contains("1"))]
+            "qux": 'required|not.contains:1' #== [Required, Not(Contains("1"))]
         }
         test_case_list = {
-            "foo": ["1", "2", "3"],
+            # "foo": ["1", "2", "3"],
             "qux": ["2", "3", "4"]
         }
         test_case_dict = {
-            "foo": {"1": "one", "2": "two"},
+            # "foo": {"1": "one", "2": "two"},
             "qux": {"2": "two", "3": "three"}
         }
         test_case_substring = {
-            "foo": "test1case",
+            # "foo": "test1case",
             "qux": "barbaz"
         }
         assert validate(validation, test_case_list)[0]

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -62,11 +62,17 @@ class TestValidator(object):
         assert validate(validator, values)[0]
         assert validate(kw_validator, values_kw)[0]
 
-    def test_truthy_validator(self):
+    def test_truthy_validator(self): 
         validator = {
             "truthiness": [Truthy()],
             "falsiness": [Not(Truthy())]
         }
+
+        str_validator = {
+            "truthiness": 'truthy',
+            "falsiness": 'not.truthy'
+        }
+
         str_value = {
             "truthiness": "test",
             "falsiness": ""
@@ -79,15 +85,23 @@ class TestValidator(object):
             "truthiness": True,
             "falsiness": False
         }
-        assert validate(validator, str_value)[0]
-        assert validate(validator, int_value)[0]
-        assert validate(validator, bool_value)[0]
+
+        for validator in (str_validator, validator):
+            assert validate(validator, str_value)[0]
+            assert validate(validator, int_value)[0]
+            assert validate(validator, bool_value)[0]
 
     def test_required_validator(self):
         validator = {
             "truthiness": [Required],
             "falsiness": []
         }
+
+        str_validator = {
+            "truthiness": 'required',
+            "falsiness": []
+        }
+
         str_value = {
             "truthiness": "test"
         }
@@ -98,17 +112,24 @@ class TestValidator(object):
             "truthiness": True
         }
         missing_value = {}
-        assert validate(validator, str_value)[0]
-        assert validate(validator, int_value)[0]
-        assert validate(validator, bool_value)[0]
-        validity, errors = validate(validator, missing_value)
-        assert errors['truthiness'] == ["must be present"]
+        for validator in (validator, str_validator):
+            assert validate(validator, str_value)[0]
+            assert validate(validator, int_value)[0]
+            assert validate(validator, bool_value)[0]
+            validity, errors = validate(validator, missing_value)
+            assert errors['truthiness'] == ["must be present"]
 
     def test_blank_validator(self):
         validator = {
             "truthiness": [Blank()],
             "falsiness": [Not(Blank())]
         }
+
+        str_validator = {
+            "truthiness": 'blank',
+            "falsiness": 'not.blank'
+        }
+
         str_value = {
             "truthiness": "",
             "falsiness": "not_blank"
@@ -121,51 +142,44 @@ class TestValidator(object):
             "truthiness": True,
             "falsiness": False
         }
-        assert validate(validator, str_value)[0]
-        assert not validate(validator, int_value)[0]
-        assert not validate(validator, bool_value)[0]
+        for validator in (validator, str_validator):
+            assert validate(validator, str_value)[0]
+            assert not validate(validator, int_value)[0]
+            assert not validate(validator, bool_value)[0]
 
     def test_in_validator(self):
         validator = {
-            "truthiness": [Truthy()],
-            "falsiness": [Not(Truthy())]
+            "truthiness": [In([1,2])],
+            "falsiness": [Not(In([1, 2]))]
         }
-        str_value = {
-            "truthiness": "test",
-            "falsiness": ""
+        str_validator = {
+            "truthiness": 'in:1,2',
+            "falsiness": 'not.in:1,2'
         }
         int_value = {
             "truthiness": 1,
-            "falsiness": 0
+            "falsiness": 3
         }
-        bool_value = {
-            "truthiness": True,
-            "falsiness": False
-        }
-        assert validate(validator, str_value)[0]
-        assert validate(validator, int_value)[0]
-        assert validate(validator, bool_value)[0]
+        for validator in (validator, str_validator):
+            assert validate(validator, int_value)[0]
 
     def test_equals_validator(self):
         validator = {
-            "truthiness": [Truthy()],
-            "falsiness": [Not(Truthy())]
+            "truthiness": [Equals('test')],
+            "falsiness": [Not(Equals('test'))]
         }
+
+        str_validator = {
+            "truthiness": 'equals:test',
+            "falsiness": ['not.equals:test']
+        }
+
         str_value = {
             "truthiness": "test",
-            "falsiness": ""
+            "falsiness": "nottest"
         }
-        int_value = {
-            "truthiness": 1,
-            "falsiness": 0
-        }
-        bool_value = {
-            "truthiness": True,
-            "falsiness": False
-        }
-        assert validate(validator, str_value)[0]
-        assert validate(validator, int_value)[0]
-        assert validate(validator, bool_value)[0]
+        for validator in (validator, str_validator):
+            assert validate(validator, str_value)[0]
 
     def test_not_validator(self):
         validator = {
@@ -176,6 +190,15 @@ class TestValidator(object):
             "test_range":   [Not(Range(1, 10))],
             "test_pattern": [Not(Pattern(r"\d\d\d"))]
         }
+
+        str_validator = {
+            "test_truthy":  'not.truthy',
+            "test_equals":  'not.equals:one',
+            "test_not_not": [Not(Not(Truthy()))],
+            "test_in":      'not.in:one,two',
+            "test_range":   'not.range:1,10',
+            "test_pattern": 'not.pattern:\d\d\d'
+        }
         test_case = {
             "test_truthy": False,
             "test_equals": "two",
@@ -184,7 +207,8 @@ class TestValidator(object):
             "test_range": 11,
             "test_pattern": "abc"
         }
-        assert validate(validator, test_case)[0]
+        for validator in (validator, str_validator):
+            assert validate(validator, test_case)[0]
 
     def test_range_validator(self):
         validator = {
@@ -193,13 +217,22 @@ class TestValidator(object):
             "exclusive_in_range": [Range(1, 10, inclusive=False)],
             "exclusive_out_of_range": [Not(Range(1, 10, inclusive=False))]
         }
+
+        str_validator = {
+            "in_range": 'range:1,10',
+            "out_of_range": 'not.range:1,10',
+            "exclusive_in_range": [Range(1, 10, inclusive=False)],
+            "exclusive_out_of_range": [Not(Range(1, 10, inclusive=False))]
+        }
+
         test_case = {
             "in_range": 1,
             "out_of_range": 11,
             "exclusive_in_range": 2,
             "exclusive_out_of_range": 1
         }
-        assert validate(validator, test_case)[0]
+        for validator in (validator, str_validator):
+            assert validate(validator, test_case)[0]
 
     def test_greaterthan_validator(self):
         validator = {
@@ -208,13 +241,20 @@ class TestValidator(object):
             "equal_exclusive": [Not(GreaterThan(0))],
             "equal_inclusive": [GreaterThan(0, inclusive=True)]
         }
+        str_validator = {
+            "greater_than": 'greaterthan:0',
+            "lower_than": 'not.greaterthan:0',
+            "equal_exclusive": 'not.greaterthan:0',
+            "equal_inclusive": [GreaterThan(0, inclusive=True)]
+        }
         test_case = {
             "greater_than": 1,
             "lower_than": -1,
             "equal_exclusive": 0,
             "equal_inclusive": 0
         }
-        assert validate(validator, test_case)[0]
+        for validator in (validator, str_validator):
+            assert validate(validator, test_case)[0]
 
     def test_lessthan_validator(self):
         validator = {
@@ -223,13 +263,20 @@ class TestValidator(object):
             "equal_exclusive": [Not(LessThan(0))],
             "equal_inclusive": [LessThan(0, inclusive=True)]
         }
+        str_validator = {
+            "less_than": 'lessthan:0',
+            "greater_than": 'not.lessthan:0',
+            "equal_exclusive": 'not.lessthan:0',
+            "equal_inclusive": [LessThan(0, inclusive=True)]
+        }
         test_case = {
             "less_than": -1,
             "greater_than": 1,
             "equal_exclusive": 0,
             "equal_inclusive": 0
         }
-        assert validate(validator, test_case)[0]
+        for validator in (validator, str_validator):
+            assert validate(validator, test_case)[0]
 
     def test_instanceof_validator(self):
         validator = {
@@ -259,15 +306,20 @@ class TestValidator(object):
 
     def test_pattern_validator(self):
         validator = {
-            # "match": [Required, Pattern(r'')],
-            "match": 'required|pattern:\d\d\%',
+            "match": [Required, Pattern(r'')],
             "no_match": [Required, Not(Pattern(r'\d\d\%'))]
         }
+        str_validator = {
+            "match": 'required|pattern:',
+            "no_match": 'required|not.pattern:\d\d\%'
+        }
+
         test_case = {
             "match": "39%",
             "no_match": "ab%"
         }
-        assert validate(validator, test_case)[0]
+        for validator in (validator, str_validator):
+            assert validate(validator, test_case)[0]
 
     def test_conditional_validator(self):
         passes = {
@@ -340,8 +392,14 @@ class TestValidator(object):
     def test_contains_validator(self):
         validation = {
             "foo": [Required, Contains("1")],
+            "qux": [Required, Not(Contains("1"))]
+        }
+
+        str_validation = {
+            "foo": 'required|contains:1',
             "qux": 'required|not.contains:1' #== [Required, Not(Contains("1"))]
         }
+
         test_case_list = {
             "foo": ["1", "2", "3"],
             "qux": ["2", "3", "4"]
@@ -354,9 +412,10 @@ class TestValidator(object):
             "foo": "test1case",
             "qux": "barbaz"
         }
-        assert validate(validation, test_case_list)[0]
-        assert validate(validation, test_case_dict)[0]
-        assert validate(validation, test_case_substring)[0]
+        for validation in (validation, str_validation):
+            assert validate(validation, test_case_list)[0]
+            assert validate(validation, test_case_dict)[0]
+            assert validate(validation, test_case_substring)[0]
 
     def test_length_validator(self):
         with pytest.raises(ValueError):
@@ -367,27 +426,45 @@ class TestValidator(object):
             "foo": [Required, Length(5), Length(1, maximum=5)],
             "bar": [Required, Length(0, maximum=10)]
         }
+        str_passes = {
+            "foo": 'required|length:5|length:1,5',
+            "bar": 'required|length:0,10',
+        }
+
         fails = {
             "foo": [Required, Length(8), Length(1, maximum=11)],
             "bar": [Required, Length(0, maximum=3)]
         }
+        str_fails = {
+            "foo": 'required|length:9|length:1,11',
+            "bar": 'required|length:0,3'
+        }
+
         test_case = {
             "foo": "12345",
             "bar": [1, 2, 3, 4, 5],
         }
-        assert validate(passes, test_case)[0]
-        assert not validate(fails, test_case)[0]
+
+        for passes in (passes, str_passes):
+            assert validate(passes, test_case)[0]
+        for fails in (fails, str_fails):
+            assert not validate(fails, test_case)[0]
 
     def test_validator_without_list(self):
         validation = {
             "foo": Equals(5),
             "bar": Required
         }
+        str_validation = {
+            "foo": 'equals:5',
+            "bar": 'required'
+        }
         test_case = {
             "foo": 5,
             "bar": "present"
         }
-        assert validate(validation, test_case)[0]
+        for validation in (validation, str_validation):
+            assert validate(validation, test_case)[0]
 
     def test_each_validator(self):
         passes = {
@@ -406,22 +483,32 @@ class TestValidator(object):
                 })
             ]
         }
-        valid, errors = validate(validation, passes)
-        assert valid
-        assert len(errors) == 0
-        valid, errors = validate(validation, fails)
-        assert not valid
-        assert len(errors) == 2
-        assert errors == {
-            "foo": ["all values must fall between 0 and 10"],
-            "bar": [{
-                0: {"qux": ["must fall between 0 and 2"]},
-                1: {
-                    "qux": ["must fall between 0 and 2"],
-                    "zot": ["must be one of [1, 2, 3]"]
-                }
-            }]
+        str_validation = {
+            "foo": [Required, Each([Range(0, 10)])],
+            "bar": [Required, Each({
+                    "qux": [Required, Range(0, 2)],
+                    "zot": [In([1, 2, 3])]
+                })
+            ]
         }
+        
+        for validation in (validation, str_validation):
+            valid, errors = validate(validation, passes)
+            assert valid
+            assert len(errors) == 0
+            valid, errors = validate(validation, fails)
+            assert not valid
+            assert len(errors) == 2
+            assert errors == {
+                "foo": ["all values must fall between 0 and 10"],
+                "bar": [{
+                    0: {"qux": ["must fall between 0 and 2"]},
+                    1: {
+                        "qux": ["must fall between 0 and 2"],
+                        "zot": ["must be one of [1, 2, 3]"]
+                    }
+                }]
+            }
 
     def test_exception_handling(self):
         validation = {

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -467,3 +467,14 @@ class TestValidator(object):
         valid, errors = validate(validation, fails)
         assert not valid
         assert len(errors) == 4
+
+class TestValidationMapper:
+
+    def setup_method(self):
+        self.mapper = ValidationMapper()
+    
+    def test_can_make_required(self):
+        assert self.mapper.make('required') == [Required]
+
+    def test_can_make_multiple_from_string(self):
+        assert self.mapper.make('required|email') == [Required, Email()]

--- a/validator/__init__.py
+++ b/validator/__init__.py
@@ -758,10 +758,7 @@ def _validate_and_store_errs(validator, dictionary, key, errors):
     # there could be actual problems with a validator, but we're just going
     # to have to rely on tests preventing broken things.
     try:
-        if isinstance(validator, str):
-            valid = ValidationMapper().make(validator)[0](dictionary[key])
-        else:
-            valid = validator(dictionary[key])
+        valid = validator(dictionary[key])
     except Exception:
         # Since we caught an exception while trying to validate,
         # treat it as a failure and return the normal error message
@@ -807,4 +804,8 @@ def _validate_list_helper(validation, dictionary, key, errors):
                         errors[key].append(dependent[1])
                 # handling for normal validators
                 else:
-                    _validate_and_store_errs(v, dictionary, key, errors)
+                    if isinstance(v, str):
+                        for validation in ValidationMapper().make(v):
+                            _validate_and_store_errs(validation, dictionary, key, errors)
+                    else:
+                        _validate_and_store_errs(v, dictionary, key, errors)

--- a/validator/__init__.py
+++ b/validator/__init__.py
@@ -704,6 +704,8 @@ class ValidationMapper:
         'lessthan': LessThan,
         'greaterthan': GreaterThan,
         'range': Range,
+        'not': Not,
+        '!': Not,
     }
 
     def make(self, string):
@@ -720,6 +722,11 @@ class ValidationMapper:
         list_validation = []
         for validation in parsed_validators:
             args = []
+            if '.' in validation:
+                rule = validation.split('.')[0]
+                list_validation.append(self.validators[rule](
+                    *self.make(validation.split('.')[1])))
+                continue
             if ":" in validation:
                 args = validation.split(':')[1].split(',')
                 validation = validation.split(':')[0]

--- a/validator/__init__.py
+++ b/validator/__init__.py
@@ -730,8 +730,8 @@ class ValidationMapper:
             if ":" in validation:
                 args = validation.split(':')[1].split(',')
                 validation = validation.split(':')[0]
-                if hasattr(self, '{}_arg_rule'.format(validation)):
-                    args = getattr(self, '{}_arg_rule'.format(validation))(*args)
+                if hasattr(self, '{0}_arg_rule'.format(validation)):
+                    args = getattr(self, '{0}_arg_rule'.format(validation))(*args)
 
             if args:
                 validator = self.validators[validation](*args)

--- a/validator/__init__.py
+++ b/validator/__init__.py
@@ -647,6 +647,20 @@ def validate(validation, dictionary):
     else:
         return ValidationResult(valid=True, errors={})
 
+class ValidationMapper:
+
+    validators = {
+        'required': Required,
+        'email': Email(),
+    }
+
+    def make(self, string):
+        parsed_validators = string.split('|')
+        list_validation = []
+        for validation in parsed_validators:
+            list_validation.append(self.validators[validation])
+        return list_validation
+
 def _validate_and_store_errs(validator, dictionary, key, errors):
 
     # Validations shouldn't throw exceptions because of

--- a/validator/__init__.py
+++ b/validator/__init__.py
@@ -694,7 +694,7 @@ class ValidationMapper:
             args = []
             if ":" in validation:
                 args = validation.split(':')[1].split(',')
-                args = [int(elem) for elem in args if unicode(elem, 'utf-8').isnumeric()]
+                args = [int(elem) for elem in args if elem.isnumeric()]
                 validation = validation.split(':')[0]
 
             if args:

--- a/validator/__init__.py
+++ b/validator/__init__.py
@@ -753,7 +753,7 @@ class ValidationMapper:
         
         :return: list
         """
-        return [int(elem) for elem in args if elem.isnumeric()]
+        return [int(elem) for elem in args if elem.isdigit()]
 
 def _validate_and_store_errs(validator, dictionary, key, errors):
 

--- a/validator/__init__.py
+++ b/validator/__init__.py
@@ -706,6 +706,7 @@ class ValidationMapper:
         'range': Range,
         'not': Not,
         '!': Not,
+        'each': Each
     }
 
     def make(self, string):
@@ -754,6 +755,87 @@ class ValidationMapper:
         :return: list
         """
         return [int(elem) for elem in args if elem.isdigit()]
+
+    def in_arg_rule(self, *args):
+        """
+        Special rule for the length validator.
+
+        This special rule is passed an *args list and then must return an iterable
+        to then be passed into the actual argument list of the validator. This is
+        useful for converting necessary parameters such as integer casting.
+        
+        :return: list
+        """
+        args = [int(elem) for elem in args if elem.isdigit()]
+        return [args]
+
+    def each_arg_rule(self, *args):
+        """
+        Special rule for the length validator.
+
+        This special rule is passed an *args list and then must return an iterable
+        to then be passed into the actual argument list of the validator. This is
+        useful for converting necessary parameters such as integer casting.
+        
+        :return: list
+        """
+        # args = [int(elem) for elem in args if elem.isdigit()]
+        return [args]
+
+    def range_arg_rule(self, *args):
+        """
+        Special rule for the length validator.
+
+        This special rule is passed an *args list and then must return an iterable
+        to then be passed into the actual argument list of the validator. This is
+        useful for converting necessary parameters such as integer casting.
+        
+        :return: list
+        """
+        return [int(elem) for elem in args if elem.isdigit()]
+
+    def greaterthan_arg_rule(self, *args):
+        """
+        Special rule for the length validator.
+
+        This special rule is passed an *args list and then must return an iterable
+        to then be passed into the actual argument list of the validator. This is
+        useful for converting necessary parameters such as integer casting.
+        
+        :return: list
+        """
+        return [int(args[0])]
+ 
+    def lessthan_arg_rule(self, *args):
+        """
+        Special rule for the length validator.
+
+        This special rule is passed an *args list and then must return an iterable
+        to then be passed into the actual argument list of the validator. This is
+        useful for converting necessary parameters such as integer casting.
+        
+        :return: list
+        """
+        return [int(args[0])]
+
+    def equals_arg_rule(self, *args):
+        """
+        Special rule for the length validator.
+
+        This special rule is passed an *args list and then must return an iterable
+        to then be passed into the actual argument list of the validator. This is
+        useful for converting necessary parameters such as integer casting.
+        
+        :return: list
+        """
+        arg_list = []
+        for elem in args:
+            if elem.isdigit():
+                arg_list.append(int(elem))
+            else:
+                arg_list.append(elem)
+
+        return arg_list
 
 def _validate_and_store_errs(validator, dictionary, key, errors):
 

--- a/validator/__init__.py
+++ b/validator/__init__.py
@@ -687,7 +687,7 @@ class ValidationMapper:
         ValidationMapper().make('required|length:1,8')
     
     which then returns:
-    
+
         [Required, Length(1,8)]
     """
     validators = {
@@ -699,6 +699,11 @@ class ValidationMapper:
         'equals': Equals,
         'contains': Contains,
         'pattern': Pattern,
+        'truthy': Truthy,
+        'blank': Blank,
+        'lessthan': LessThan,
+        'greaterthan': GreaterThan,
+        'range': Range,
     }
 
     def make(self, string):
@@ -753,7 +758,10 @@ def _validate_and_store_errs(validator, dictionary, key, errors):
     # there could be actual problems with a validator, but we're just going
     # to have to rely on tests preventing broken things.
     try:
-        valid = validator(dictionary[key])
+        if isinstance(validator, str):
+            valid = ValidationMapper().make(validator)[0](dictionary[key])
+        else:
+            valid = validator(dictionary[key])
     except Exception:
         # Since we caught an exception while trying to validate,
         # treat it as a failure and return the normal error message

--- a/validator/__init__.py
+++ b/validator/__init__.py
@@ -685,6 +685,9 @@ class ValidationMapper:
         'email': Email,
         'length': Length,
         'in': In,
+        'url': Url,
+        'equals': Equals,
+        'contains': Contains
     }
 
     def make(self, string):

--- a/validator/__init__.py
+++ b/validator/__init__.py
@@ -694,7 +694,7 @@ class ValidationMapper:
             args = []
             if ":" in validation:
                 args = validation.split(':')[1].split(',')
-                args = [int(elem) for elem in args if elem.isnumeric()]
+                args = [int(elem) for elem in args if unicode(elem, 'utf-8').isnumeric()]
                 validation = validation.split(':')[0]
 
             if args:


### PR DESCRIPTION
This PR adds the ability for string based authentication. This PR is still a WIP but this is the foundation of how it will work.

You can now make a validator doing something like:

```python
validation = {
    "foo": 'email|required|length:1,2',
}
```

Closes #20 

## NOTE

I recommend putting this in the next major release and breaking support for anything < Python 3